### PR TITLE
Mejora de la configuración de algoritmos vía ficheros XML

### DIFF
--- a/src/main/java/miml/classifiers/miml/mimlTOmi/MIMLClassifierToMI.java
+++ b/src/main/java/miml/classifiers/miml/mimlTOmi/MIMLClassifierToMI.java
@@ -19,7 +19,6 @@ import miml.classifiers.miml.MIMLClassifier;
 import miml.core.ConfigParameters;
 import miml.data.MIMLBag;
 import miml.data.MIMLInstances;
-import mulan.classifier.InvalidDataException;
 import mulan.classifier.MultiLabelLearner;
 import mulan.classifier.MultiLabelOutput;
 import mulan.classifier.transformation.TransformationBasedMultiLabelLearner;
@@ -32,7 +31,6 @@ import weka.core.Utils;
 import java.util.Objects;
 
 /**
- * 
  * <p>
  * Class implementing the degenerative algorithm for MIML data to solve it with
  * MI learning. For more information, see <em>Zhou, Z. H., &#38; Zhang, M. L.
@@ -40,24 +38,27 @@ import java.util.Objects;
  * classification. In Advances in neural information processing systems (pp.
  * 1609-1616).</em>
  * </p>
- * 
+ *
  * @author Alvaro A. Belmonte
  * @author Eva Gibaja
  * @author Amelia Zafra
  * @version 20180701
- *
  */
 public class MIMLClassifierToMI extends MIMLClassifier {
 
-	/** Generated Serial version UID. */
+	/**
+	 * Generated Serial version UID.
+	 */
 	private static final long serialVersionUID = -1665460849023571048L;
 
-	/** Generic classifier used for transformation. */
+	/**
+	 * Generic classifier used for transformation.
+	 */
 	protected MultiLabelLearner transformationClassifier;
 
 	/**
 	 * Basic constructor.
-	 * 
+	 *
 	 * @param transformationClassifier Mulan MultiLabelLearner used as
 	 *                                 transformation method from MIML to MI.
 	 */
@@ -74,7 +75,7 @@ public class MIMLClassifierToMI extends MIMLClassifier {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see mimlclassifier.MIMLClassifier#buildInternal(data.MIMLInstances)
 	 */
 	@Override
@@ -82,22 +83,21 @@ public class MIMLClassifierToMI extends MIMLClassifier {
 		MultiLabelInstances mlData = new MultiLabelInstances(trainingSet.getDataSet(), trainingSet.getLabelsMetaData());
 		transformationClassifier.setDebug(getDebug());
 		transformationClassifier.build(mlData);
-
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see mimlclassifier.MIMLClassifier#makePredictionInternal(data.Bag)
 	 */
 	@Override
-	protected MultiLabelOutput makePredictionInternal(MIMLBag instance) throws Exception, InvalidDataException {
+	protected MultiLabelOutput makePredictionInternal(MIMLBag instance) throws Exception {
 		return transformationClassifier.makePrediction(instance);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * core.IConfiguration#configure(org.apache.commons.configuration.Configuration)
 	 */

--- a/src/main/java/miml/classifiers/miml/mimlTOml/MIMLClassifierToML.java
+++ b/src/main/java/miml/classifiers/miml/mimlTOml/MIMLClassifierToML.java
@@ -20,7 +20,6 @@ import miml.core.ConfigParameters;
 import miml.data.MIMLBag;
 import miml.data.MIMLInstances;
 import miml.transformation.mimlTOml.MIMLtoML;
-import mulan.classifier.InvalidDataException;
 import mulan.classifier.MultiLabelLearner;
 import mulan.classifier.MultiLabelOutput;
 import mulan.data.MultiLabelInstances;
@@ -30,7 +29,6 @@ import weka.core.Instance;
 import java.util.Objects;
 
 /**
- * 
  * <p>
  * Class implementing the degenerative algorithm for MIML data to solve it with
  * ML learning. For more information, see <em>Zhou, Z. H., &#38; Zhang, M. L.
@@ -38,25 +36,32 @@ import java.util.Objects;
  * classification. In Advances in neural information processing systems (pp.
  * 1609-1616).</em>
  * </p>
- * 
+ *
  * @author Alvaro A. Belmonte
  * @author Eva Gibaja
  * @author Amelia Zafra
  * @version 20180608
- *
  */
 public class MIMLClassifierToML extends MIMLClassifier {
 
-	/** Generated Serial version UID. */
+	/**
+	 * Generated Serial version UID.
+	 */
 	private static final long serialVersionUID = 1L;
 
-	/** A Generic MultiLabel classifier. */
+	/**
+	 * A Generic MultiLabel classifier.
+	 */
 	protected MultiLabelLearner baseClassifier;
 
-	/** The transform method. */
+	/**
+	 * The transform method.
+	 */
 	protected MIMLtoML transformMethod;
 
-	/** The miml dataset. */
+	/**
+	 * The miml dataset.
+	 */
 	protected MIMLInstances mimlDataset;
 
 	/**
@@ -80,12 +85,11 @@ public class MIMLClassifierToML extends MIMLClassifier {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see mimlclassifier.MIMLClassifier#buildInternal(data.MIMLInstances)
 	 */
 	@Override
 	public void buildInternal(MIMLInstances mimlDataSet) throws Exception {
-
 		// Transforms a dataset
 		MultiLabelInstances mlDataSet = transformMethod.transformDataset(mimlDataSet);
 		baseClassifier.build(mlDataSet);
@@ -93,18 +97,18 @@ public class MIMLClassifierToML extends MIMLClassifier {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see mimlclassifier.MIMLClassifier#makePredictionInternal(data.Bag)
 	 */
 	@Override
-	protected MultiLabelOutput makePredictionInternal(MIMLBag bag) throws Exception, InvalidDataException {
+	protected MultiLabelOutput makePredictionInternal(MIMLBag bag) throws Exception {
 		Instance instance = transformMethod.transformInstance(bag);
 		return baseClassifier.makePrediction(instance);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * core.IConfiguration#configure(org.apache.commons.configuration.Configuration)
 	 */
@@ -212,7 +216,4 @@ public class MIMLClassifierToML extends MIMLClassifier {
 		ConfigParameters.setTransformMethod(transformerName);
 		ConfigParameters.setIsDegenerative(true);
 	}
-	
-	
-
 }


### PR DESCRIPTION
Cambios en la configuración de algoritmos que transforman de MIML a MI como de MIML a ML:
- En los algoritmos de MI de Weka que se configuran con la etiqueta <listOptions> la separación de la cadena en cada uno de los parámetros daba problemas si había configuraciones anidadas entre "". Se propone usar un método propio de Weka y que no da problemas y simplifica el código.
- En los algoritmos de ML se añade la posibilidad de añadir parámetros anidados a la configuración de algoritmos, fundamental para algoritmos de tipo meta que reciben un MultiLabelLearner que a su vez se instancia con un Classifier. También se resuelve la instanciación de parámetros tipo Enum.